### PR TITLE
Added incremental updates

### DIFF
--- a/core_stock.py
+++ b/core_stock.py
@@ -2,10 +2,12 @@ import pandas as pd
 
 from collector import AlphaVantageClient
 from storage import store_data
+from util import drop_existing_rows, get_table_write_option
 
 
 CORE_STOCK_TABLE_NAME = 'core_stock'
 CORE_STOCK_COLUMNS = ['open', 'high', 'low', 'adjusted_close', 'volume']
+DATE_COL = 'date'
 
 
 def fetch_daily_adjusted_data(api_client: AlphaVantageClient, symbol: str, incremental: bool = True):
@@ -24,11 +26,12 @@ def parse_daily_adjusted_data(data: dict):
     time_series = data['Time Series (Daily)']
     df = pd.DataFrame.from_dict(time_series, orient='index')
     df.index = pd.to_datetime(df.index)
-    df.index.name = 'date'
+    df.index.name = DATE_COL
     # Update column names to be everything after the first space, then replace the rest of the spaces with underscores
     df.columns = [col[col.index(' ')+1:].replace(' ', '_') for col in df.columns]
     # Filter down to only the columns we care about
     df = df.filter(items=CORE_STOCK_COLUMNS)
+    # Every value in the table is a number, so we can convert the whole table to numeric
     df = df.apply(pd.to_numeric)
     return df
 
@@ -37,6 +40,10 @@ def update_core_stock_data(api_client: AlphaVantageClient, symbol: str, incremen
     response = fetch_daily_adjusted_data(api_client, symbol, incremental)
     core_stock_df = parse_daily_adjusted_data(response)
     core_stock_df['symbol'] = symbol
+
+    if incremental:
+        core_stock_df = drop_existing_rows(core_stock_df, CORE_STOCK_TABLE_NAME, DATE_COL, symbol)
+
     print(f'{symbol} core data')
     print(core_stock_df.head())
-    store_data(core_stock_df, table_name=CORE_STOCK_TABLE_NAME)
+    store_data(core_stock_df, table_name=CORE_STOCK_TABLE_NAME, write_option=get_table_write_option(incremental))

--- a/fundamental_data.py
+++ b/fundamental_data.py
@@ -2,7 +2,8 @@ import pandas as pd
 import inflection
 
 from collector import AlphaVantageClient
-from storage import store_data
+from storage import store_data, TableWriteOption
+from util import drop_existing_rows, get_table_write_option, graceful_df_to_numeric
 
 from enum import Enum
 
@@ -15,7 +16,7 @@ class FundamentalDataType(Enum):
 DATA_TYPE_TABLES = {
     FundamentalDataType.OVERVIEW: {
         'table_name': 'company_overview',
-        'columns': ['exchange', 'country', 'sector', 'industry', 'market_capitalization', 'book_value', 'dividend_yield', 'eps', 'price_to_book_ratio', 'beta', '52_week_high', '52_week_low'],
+        'columns': ['exchange', 'country', 'sector', 'industry', 'market_capitalization', 'book_value', 'dividend_yield', 'eps', 'price_to_book_ratio', 'beta', '52_week_high', '52_week_low', 'forward_pe'],
         'include_index': False,
     },
     FundamentalDataType.EARNINGS: {
@@ -24,6 +25,7 @@ DATA_TYPE_TABLES = {
         'include_index': True,
     },
 }
+EARNINGS_DATE_COL = 'fiscal_date_ending'
 
 
 def fetch_fundamental_data(api_client: AlphaVantageClient, symbol: str, data_type: FundamentalDataType):
@@ -34,38 +36,60 @@ def fetch_fundamental_data(api_client: AlphaVantageClient, symbol: str, data_typ
     return api_client.fetch(**params)
 
 
-def parse_overview(data: dict):
+def parse_overview(data: dict, symbol: str):
     data = {key: [value] for key, value in data.items()}
     df = pd.DataFrame(data)
     df.columns = [inflection.underscore(col) for col in df.columns]
     df = df.filter(items=DATA_TYPE_TABLES[FundamentalDataType.OVERVIEW]['columns'])
+    df = graceful_df_to_numeric(df)
+    # We add in the symbol after converting to numeric because it's not a numeric column.
+    df['symbol'] = symbol
     return df
 
 
-def parse_earnings(data: dict):
+def parse_earnings(data: dict, symbol: str):
     key = 'quarterlyEarnings'
     if key not in data:
         raise ValueError(f"Unexpected response format: '{key}' key not found")
 
     df = pd.DataFrame(data[key])
     df.set_index('fiscalDateEnding', inplace=True)
-    df.index.name = 'fiscal_date_ending'
+    df.index.name = EARNINGS_DATE_COL
     df.index = pd.to_datetime(df.index)
 
     df.columns = [inflection.underscore(col) for col in df.columns]
     df = df.filter(items=DATA_TYPE_TABLES[FundamentalDataType.EARNINGS]['columns'])
+
+    # All this data is numeric, but it's possible to have Nones. We don't need to apply numeric gracefully because
+    # if it fails, due to the data being None, it will convert to NaN, which is fine because it becomes NULL in MySQL.
+    df = df.apply(pd.to_numeric, errors='coerce')
+
+    # We add in the symbol after converting to numeric because it's not a numeric column.
+    df['symbol'] = symbol
+
     print(df.head())
     return df
 
 
-def update_all_fundamental_data(api_client: AlphaVantageClient, symbol: str):
+def update_all_fundamental_data(api_client: AlphaVantageClient, symbol: str, incremental: bool = True):
     for data_type in FundamentalDataType:
         response = fetch_fundamental_data(api_client, symbol, data_type)
-        df = DATA_TYPE_PARSERS[data_type](response)
-        df['symbol'] = symbol
+        df = DATA_TYPE_PARSERS[data_type](response, symbol)
+
+        # Currently, company_overview is just a snapshot, so it doesn't support incremental updates.
+        write_option = get_table_write_option(incremental) if data_type == FundamentalDataType.EARNINGS else TableWriteOption.REPLACE
+        if write_option == TableWriteOption.APPEND:
+            df = drop_existing_rows(df, DATA_TYPE_TABLES[data_type]['table_name'], EARNINGS_DATE_COL, symbol)
+
         print(f'{data_type.value} data')
         print(df.head())
-        store_data(df, table_name=DATA_TYPE_TABLES[data_type]['table_name'], index=DATA_TYPE_TABLES[data_type]['include_index'])
+
+        store_data(
+            df,
+            table_name=DATA_TYPE_TABLES[data_type]['table_name'],
+            write_option=write_option,
+            include_index=DATA_TYPE_TABLES[data_type].get('include_index', True),
+        )
 
 
 # Functions to parse fundamental various types of data responses into dataframes

--- a/main.py
+++ b/main.py
@@ -6,35 +6,36 @@ from fundamental_data import update_all_fundamental_data
 from technical_indicator import update_all_technical_indicators
 
 
+INCREMENTAL = False
+
+
 def main():
     # Fetch data for NVDA
     symbol = 'NVDA'
 
     # Update core stock data
     try:
-        # TODO: Add incremental flag to only fetch new data
-        update_core_stock_data(alpha_client, symbol, incremental=False)
+        update_core_stock_data(alpha_client, symbol, incremental=INCREMENTAL)
     except Exception as e:
         print(f"Error fetching historical data: {e}")
         return
 
     # Update technical indicators
     try:
-        update_all_technical_indicators(alpha_client, symbol)
+        update_all_technical_indicators(alpha_client, symbol, incremental=INCREMENTAL)
     except Exception as e:
         print(f"Error updating technical indicator data: {e}")
 
     # Update all fundamental data
     try:
-        update_all_fundamental_data(alpha_client, symbol)
+        update_all_fundamental_data(alpha_client, symbol, incremental=INCREMENTAL)
     except Exception as e:
         print(f"Error fetching fundamental data: {e}")
         return
 
     # Fetch and parse economic indicators
     try:
-        # TODO: Add incremental flag to only fetch new data
-        update_all_economic_indicators(alpha_client, incremental=False)
+        update_all_economic_indicators(alpha_client, incremental=INCREMENTAL)
     except Exception as e:
         print(f"Error updating economic indicators: {e}")
 

--- a/storage.py
+++ b/storage.py
@@ -1,6 +1,7 @@
 import os
+from enum import Enum
 
-from sqlalchemy import create_engine, MetaData, text
+from sqlalchemy import create_engine, text
 
 import pandas as pd
 
@@ -10,6 +11,14 @@ host = '127.0.0.1'
 port = 3306
 dbname = 'bar_fly_trading'
 
+
+# Methods for writing to a table. These methods apply at a table level, not a row level.
+# i.e. APPEND will add new rows to the table, REPLACE will replace the entire table with the new data.
+class TableWriteOption(Enum):
+    APPEND = 'append'
+    REPLACE = 'replace'
+
+
 if not password:
     raise Exception('Must set MYSQL_PASSWORD environment variable')
 
@@ -18,9 +27,14 @@ def create_database():
     return create_engine(connection_string)
 
 
-def store_data(df, table_name, index=True):
-    # TODO: Add an option to append instead of replace for incremental updates
-    df.to_sql(table_name, engine, if_exists='replace', index=index)
+def store_data(df, table_name, write_option: TableWriteOption, include_index=True):
+    if df.empty:
+        print(f'No data to store in {table_name}.')
+        return
+
+    # TODO: When replacing a table, we should drop and recreate the table manually so we can create PKs.
+    # TODO: This will guard against bugs resulting in duplicate data (e.g. core_stock for same date-symbol combo)
+    df.to_sql(table_name, engine, if_exists=write_option.value, index=include_index)
 
 
 def select_all_from_table(table_name: str, order_by: str, limit: int = 10):
@@ -31,6 +45,15 @@ def select_all_from_table(table_name: str, order_by: str, limit: int = 10):
     print(f'First {limit} rows from {table_name}:')
     pd.set_option('display.max_columns', None)
     print(df)
+
+
+def get_last_updated_date(table_name: str, date_col: str, symbol: str):
+    # Get the most recent date in the table with an optional symbol filter (not all tables have symbols)
+    query = text(f"SELECT MAX({date_col}) FROM {table_name}{' WHERE symbol = :symbol' if symbol else ''};")
+    with engine.connect() as connection:
+        result = connection.execute(query, {"symbol": symbol})
+        last_updated_date = pd.to_datetime(result.fetchone()[0])
+    return last_updated_date
 
 
 connection_string = f'mysql+pymysql://{username}:{password}@{host}:{port}/{dbname}'

--- a/util.py
+++ b/util.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from storage import TableWriteOption, get_last_updated_date
+
+
+def get_table_write_option(incremental: bool) -> TableWriteOption:
+    return TableWriteOption.APPEND if incremental else TableWriteOption.REPLACE
+
+
+# Converts all numeric values in a df to numeric, while leaving non-numeric values as is.
+def graceful_df_to_numeric(df):
+    # Create a new df that converts all columns to numeric, filling with NaN for non-numeric values
+    df_numeric = df.apply(lambda col: col.map(pd.to_numeric(col, errors='coerce')))
+    # Combine the numeric df with the original df, filling in any NaN values in the numeric df with the original values.
+    return df_numeric.combine_first(df)
+
+
+# Used when running incremental updates, this function filters out rows before (and equal to)
+# the most recent date in the table.
+def drop_existing_rows(df, table_name: str, date_col: str, symbol: str = ''):
+    last_updated_date = get_last_updated_date(table_name, date_col, symbol)
+    return df[df.index > last_updated_date]


### PR DESCRIPTION
- Added an option to update the tables incrementally (just filling in data since the last date we have in the table)
- Added a way to gracefully convert df columns to numeric types, so we no longer have tables where all columns are `text` types. This changes the schemas of some of the tables - to update your local DB, run it first with `INCREMENTAL = False`, so you get the new schemas.

For incremental updates, we're currently fetching all data and trimming down to what we need. I'll come back to this because some endpoints have the option to only request the data we need, so that should make things quicker and more efficient.