### PR TITLE
Added support for multiple symbols and PKs in DB tables

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import storage
 from collector import alpha_client
 from core_stock import update_core_stock_data
 from economic_indicator import update_all_economic_indicators
@@ -6,45 +5,44 @@ from fundamental_data import update_all_fundamental_data
 from technical_indicator import update_all_technical_indicators
 
 
-INCREMENTAL = False
+incremental = False
+SYMBOLS = ['NVDA', 'AAPL']
 
 
 def main():
-    # Fetch data for NVDA
-    symbol = 'NVDA'
+    global incremental
 
-    # Update core stock data
-    try:
-        update_core_stock_data(alpha_client, symbol, incremental=INCREMENTAL)
-    except Exception as e:
-        print(f"Error fetching historical data: {e}")
-        return
+    for symbol in SYMBOLS:
+        # Update core stock data
+        try:
+            update_core_stock_data(alpha_client, symbol, incremental=incremental)
+        except Exception as e:
+            print(f"Error fetching historical data: {e}")
+            return
 
-    # Update technical indicators
-    try:
-        update_all_technical_indicators(alpha_client, symbol, incremental=INCREMENTAL)
-    except Exception as e:
-        print(f"Error updating technical indicator data: {e}")
+        # # Update technical indicators
+        try:
+            update_all_technical_indicators(alpha_client, symbol, incremental=incremental)
+        except Exception as e:
+            print(f"Error updating technical indicator data: {e}")
 
-    # Update all fundamental data
-    try:
-        update_all_fundamental_data(alpha_client, symbol, incremental=INCREMENTAL)
-    except Exception as e:
-        print(f"Error fetching fundamental data: {e}")
-        return
+        # Update all fundamental data
+        try:
+            update_all_fundamental_data(alpha_client, symbol, incremental=incremental)
+        except Exception as e:
+            print(f"Error fetching fundamental data: {e}")
+            return
 
-    # Fetch and parse economic indicators
-    try:
-        update_all_economic_indicators(alpha_client, incremental=INCREMENTAL)
-    except Exception as e:
-        print(f"Error updating economic indicators: {e}")
+        # Fetch and parse economic indicators
+        try:
+            update_all_economic_indicators(alpha_client, incremental=incremental)
+        except Exception as e:
+            print(f"Error updating economic indicators: {e}")
 
-    for table_name in ['core_stock', 'technical_indicators', 'company_overview', 'quarterly_earnings', 'economic_indicators']:
-        order_by_overrides = {
-            'company_overview': '',
-            'quarterly_earnings': 'fiscal_date_ending',
-        }
-        storage.select_all_from_table(table_name, order_by_overrides.get(table_name, 'date'))
+        # If incremental is False, that means we want to drop the existing tables and re-insert all the data.
+        # To avoid dropping the tables on every iteration, we set incremental to True after the first iteration.
+        if not incremental:
+            incremental = True
 
 
 if __name__ == "__main__":

--- a/storage.py
+++ b/storage.py
@@ -12,6 +12,15 @@ port = 3306
 dbname = 'bar_fly_trading'
 
 
+TABLE_CREATES = {
+    'core_stock': 'CREATE TABLE core_stock(date DATETIME, open DOUBLE, high DOUBLE, low DOUBLE, adjusted_close DOUBLE, volume BIGINT, symbol VARCHAR(5), PRIMARY KEY (date, symbol));',
+    'company_overview': 'CREATE TABLE company_overview(exchange VARCHAR(10), country VARCHAR(20), sector VARCHAR(30), industry VARCHAR(50), market_capitalization bigint, book_value DOUBLE, dividend_yield DOUBLE, eps DOUBLE, price_to_book_ratio DOUBLE, beta DOUBLE, 52_week_high DOUBLE, 52_week_low DOUBLE, forward_pe DOUBLE, symbol VARCHAR(5), PRIMARY KEY (symbol));',
+    'quarterly_earnings': 'CREATE TABLE quarterly_earnings(fiscal_date_ending DATETIME, reported_eps DOUBLE, estimated_eps DOUBLE, surprise DOUBLE, surprise_percentage DOUBLE, symbol VARCHAR(5), PRIMARY KEY (fiscal_date_ending, symbol));',
+    'economic_indicators': 'CREATE TABLE economic_indicators(date DATETIME, treasury_yield_2year DOUBLE, treasury_yield_10year DOUBLE, ffer DOUBLE, cpi DOUBLE, inflation DOUBLE, retail_sales DOUBLE, durables DOUBLE, unemployment DOUBLE, nonfarm_payroll DOUBLE, PRIMARY KEY (date));',
+    'technical_indicators': 'CREATE TABLE technical_indicators(date DATETIME, sma_20 DOUBLE, sma_50 DOUBLE, sma_200 DOUBLE, ema_20 DOUBLE, ema_50 DOUBLE, ema_200 DOUBLE, macd DOUBLE, rsi_14 DOUBLE, bbands_upper_20 DOUBLE, bbands_middle_20 DOUBLE, bbands_lower_20 DOUBLE, symbol VARCHAR(5), PRIMARY KEY (date, symbol));',
+}
+
+
 # Methods for writing to a table. These methods apply at a table level, not a row level.
 # i.e. APPEND will add new rows to the table, REPLACE will replace the entire table with the new data.
 class TableWriteOption(Enum):
@@ -32,9 +41,14 @@ def store_data(df, table_name, write_option: TableWriteOption, include_index=Tru
         print(f'No data to store in {table_name}.')
         return
 
-    # TODO: When replacing a table, we should drop and recreate the table manually so we can create PKs.
-    # TODO: This will guard against bugs resulting in duplicate data (e.g. core_stock for same date-symbol combo)
-    df.to_sql(table_name, engine, if_exists=write_option.value, index=include_index)
+    if write_option == TableWriteOption.REPLACE:
+        drop_table(table_name)
+        # We create tables manually, rather than using df.to_sql, so we can set primary keys.
+        create_table(table_name)
+
+    # If we wanted to REPLACE, we've already dropped and recreated the table. That means we can always do our write as
+    # an APPEND. This ensures our tables keep their exact types (e.g. VARCHAR vs. text) and primary keys.
+    df.to_sql(table_name, engine, if_exists=TableWriteOption.APPEND.value, index=include_index)
 
 
 def select_all_from_table(table_name: str, order_by: str, limit: int = 10):
@@ -54,6 +68,30 @@ def get_last_updated_date(table_name: str, date_col: str, symbol: str):
         result = connection.execute(query, {"symbol": symbol})
         last_updated_date = pd.to_datetime(result.fetchone()[0])
     return last_updated_date
+
+
+def drop_table(table_name: str):
+    query = text(f'DROP TABLE IF EXISTS {table_name};')
+    with engine.connect() as connection:
+        connection.execute(query)
+
+
+def create_table(table_name: str):
+    if table_name not in TABLE_CREATES:
+        raise ValueError(f'No CREATE TABLE statement found for table: {table_name}')
+
+    query = text(TABLE_CREATES[table_name])
+    with engine.connect() as connection:
+        connection.execute(query)
+
+
+def delete_company_overview_row(symbol: str):
+    query = text("DELETE FROM company_overview WHERE symbol = :symbol;")
+    with engine.connect() as connection:
+        # For some reason, deleting rows seems to require a transaction
+        with connection.begin() as transaction:
+            connection.execute(query, {'symbol': symbol})
+            transaction.commit()
 
 
 connection_string = f'mysql+pymysql://{username}:{password}@{host}:{port}/{dbname}'

--- a/util.py
+++ b/util.py
@@ -10,7 +10,7 @@ def get_table_write_option(incremental: bool) -> TableWriteOption:
 # Converts all numeric values in a df to numeric, while leaving non-numeric values as is.
 def graceful_df_to_numeric(df):
     # Create a new df that converts all columns to numeric, filling with NaN for non-numeric values
-    df_numeric = df.apply(lambda col: col.map(pd.to_numeric(col, errors='coerce')))
+    df_numeric = df.apply(lambda col: pd.to_numeric(col, errors='coerce'))
     # Combine the numeric df with the original df, filling in any NaN values in the numeric df with the original values.
     return df_numeric.combine_first(df)
 
@@ -19,4 +19,4 @@ def graceful_df_to_numeric(df):
 # the most recent date in the table.
 def drop_existing_rows(df, table_name: str, date_col: str, symbol: str = ''):
     last_updated_date = get_last_updated_date(table_name, date_col, symbol)
-    return df[df.index > last_updated_date]
+    return df[df.index > last_updated_date] if last_updated_date else df


### PR DESCRIPTION
- Added loop in main script so we can process and store multiple symbols
- When running with `incremental=False` in a loop, we do that for the first iteration (symbol), then run with `incremental=True` thereafter, so we don't drop data we just added in a previous iteration.
- Previously, the core_stock API call assumed if we were running incrementally, that we could use the `compact` data argument, which only fetches the last 100 days. That doesn't work with the new looping logic where iterations 2+ are always run incrementally. We now check the last updated date in the table for the given symbol, and only if it was within 100 days, we will request the `compact` data.
- Previously, when updating the `company_overview` table, we were always replacing it (it didn't support incremental updates). This was fine when we had only 1 symbol, but doesn't work with more than 1. So now, when running incrementally, it only deletes the row of the symbol we're working on, rather than replacing the whole table.
- Reworked the DB storage logic to support primary keys and specific table schemas. Now, when not running incrementally, we'll drop the table then recreate it. This allows us to define our own schema (with PKs) instead of having pandas/SQLAlchemy do their own mapping from Python types to MySQL types. **To update your local DB schema to reflect this change, run the script once with `incremental=False`.**