### PR TITLE
Fixing fundamental data override bug

### DIFF
--- a/api_data/pull_api_data.py
+++ b/api_data/pull_api_data.py
@@ -1,9 +1,11 @@
-import pandas as pd
-import logging
 import argparse
-import time
-import sys
+import logging
 import os
+import sys
+import time
+
+import pandas as pd
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
@@ -17,7 +19,7 @@ from logging_config import setup_logging
 
 setup_logging()
 logger = logging.getLogger(__name__)
-incremental = False
+incremental = True
 
 
 def main():


### PR DESCRIPTION
- Changed `incremental` to True in `pull_api_data` so we don't drop the tables on the first iteration
- Fixed bug in fundamental_data where we were dropping the symbol's company_overview row before inserting stock split data because we didn't add a condition to check for stock splits