### PR TITLE
Using DB historical options data in backtester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea/*
+.vscode/*
+.DS_Store
 *all_data*
 */logs/*
 *.ipynb
@@ -6,4 +8,5 @@
 *.swp*
 *.png
 *.jpg
-credentials.json
+*credentials.json
+*.log

--- a/strategy/base_strategy.py
+++ b/strategy/base_strategy.py
@@ -13,5 +13,5 @@ class BaseStrategy(ABC):
         self.symbols = symbols
 
     @abstractmethod
-    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame) -> list[Order]:
+    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame, options_data: pd.DataFrame) -> list[Order]:
         pass

--- a/strategy/bollinger_bands_strategy.py
+++ b/strategy/bollinger_bands_strategy.py
@@ -18,7 +18,7 @@ class BollingerBandsStrategy(BaseStrategy):
         # Remove any rows where symbol is not in symbols
         self.historical_data = self.historical_data[self.historical_data['symbol'].isin(symbols)]
 
-    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame) -> list[Order]:
+    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame, options_data: pd.DataFrame) -> list[Order]:
         orders = []
         date = date.strftime('%Y-%m-%d')
         # evenly distribute the cash among the stocks

--- a/strategy/buy_hold_strategy.py
+++ b/strategy/buy_hold_strategy.py
@@ -11,7 +11,6 @@ from strategy.base_strategy import BaseStrategy
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
-
 class BuyHoldStrategy(BaseStrategy):
     def __init__(self, account, symbols):
         super().__init__(account, symbols)
@@ -19,7 +18,7 @@ class BuyHoldStrategy(BaseStrategy):
         # Remove any columns where symbol is not in symbols
         self.historical_data = self.historical_data[self.historical_data['symbol'].isin(symbols)]
 
-    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame) -> list[Order]:
+    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame, options_data: pd.DataFrame) -> list[Order]:
         orders = []
         date = date.strftime('%Y-%m-%d')
         # evenly distribute the cash among the stocks

--- a/strategy/technical_heuristics_strategy.py
+++ b/strategy/technical_heuristics_strategy.py
@@ -35,7 +35,7 @@ class TechnicalHeuristicsStrategy(BaseStrategy):
         # Remove any rows where symbol is not in symbols
         self.historical_data = self.historical_data[self.historical_data['symbol'].isin(symbols)]
 
-    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame) -> list[Order]:
+    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame, options_data: pd.DataFrame) -> list[Order]:
         orders = []
         date = date.strftime('%Y-%m-%d')
 

--- a/strategy/technical_strategy.py
+++ b/strategy/technical_strategy.py
@@ -13,7 +13,7 @@ class TechnicalStrategy(BaseStrategy):
         # Remove any columns where symbol is not in symbols
         self.historical_data = self.historical_data[self.historical_data['symbol'].isin(symbols)]
 
-    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame) -> list[Order]:
+    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame, options_data: pd.DataFrame) -> list[Order]:
         orders = []
         date = date.strftime('%Y-%m-%d')
 

--- a/strategy/test_strategy.py
+++ b/strategy/test_strategy.py
@@ -7,7 +7,7 @@ from strategy.base_strategy import BaseStrategy
 
 
 class TestStrategy(BaseStrategy):
-    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame) -> list[Order]:
+    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame, options_data: pd.DataFrame) -> list[Order]:
         # Buy 1 share of each stock in self.symbols
         orders = []
         for symbol in self.symbols:

--- a/strategy/weekly_call_strategy.py
+++ b/strategy/weekly_call_strategy.py
@@ -1,0 +1,69 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from order import Order, OrderOperation, OptionType, OptionOrder
+from strategy.base_strategy import BaseStrategy
+from util import get_atm_strike_data
+
+
+class WeeklyCallStrategy(BaseStrategy):
+    """
+    Buys an at-the-money call option for each symbol on Monday, expiring on Friday.
+
+    This is only meant for testing. Since we're currently only buying on Mondays and selling on Fridays,
+    it'll skip weeks with Monday holidays, and will fail if there's a Friday holiday. If you're fine with
+    skipping weeks with Monday holidays, you can use this strategy, as long as the test window has no Friday holidays.
+    """
+    def __init__(self, account, symbols):
+        super().__init__(account, symbols)
+
+    def evaluate(self, date: datetime.date, current_prices: pd.DataFrame, options_data: pd.DataFrame) -> list[Order]:
+        orders = []
+
+        # Check if the date is a Monday or a Friday
+        if date.weekday() == 0:
+            # Buy a call option for each symbol
+            for symbol in self.symbols:
+                current_price = current_prices.loc[current_prices['symbol'] == symbol, 'open'].iloc[0]
+                atm_strike_data = get_atm_strike_data(symbol, current_price, options_data)
+                if atm_strike_data is None:
+                    print(f"No ATM strike data found for {symbol} on {date}, skipping")
+                    continue
+
+                # Filter down to just calls
+                atm_strike_data = atm_strike_data[atm_strike_data['type'] == 'call']
+                # Get the latest date this week. Usually Friday, but this accounts for holidays.
+                friday_date = (date + timedelta(days=4)).date()
+                this_weeks_options = atm_strike_data[atm_strike_data['expiration'] <= friday_date]
+
+                # Get the row with the latest expiration date among the filtered ones
+                if this_weeks_options.empty:
+                    print("No expiration dates within the next 4 days.")
+                else:
+                    latest = this_weeks_options.loc[this_weeks_options['expiration'].idxmax()]
+                    orders.append(
+                        OptionOrder(symbol, OrderOperation.BUY, latest['contract_id'], OptionType.CALL, 1, latest['ask'],
+                                    latest['strike'], latest['expiration'], date.strftime('%Y-%m-%d'))
+                    )
+        elif date.weekday() == 4:
+            # Get all option orders we placed on Monday
+            monday_date = (date - timedelta(days=4)).strftime('%Y-%m-%d')
+            orders_history = self.account.order_history.get_filtered_order_history(start_date=monday_date, end_date=monday_date, order_types=[OptionOrder], order_operation=OrderOperation.BUY)
+
+            # Sell all option orders we placed on Monday
+            for symbol, symbol_orders in orders_history.items():
+                for _, order_id_dict in symbol_orders.items():
+                    for _, order in order_id_dict.items():
+                        if order.option_type != OptionType.CALL:
+                            continue
+
+                        # Get the latest bid price for the option and sell it
+                        current_price = options_data.loc[options_data['contract_id'] == order.contract_id, 'bid'].iloc[0]
+                        orders.append(
+                            OptionOrder(order.symbol, OrderOperation.SELL, order.contract_id, order.option_type, order.quantity,
+                                        current_price, order.strike_price, order.expiration_date, date.strftime('%Y-%m-%d'))
+                        )
+
+        return orders
+

--- a/util.py
+++ b/util.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 
+import pandas
+
 
 def get_closest_trading_date(input_date):
     input_date = datetime.strptime(input_date, '%Y-%m-%d')
@@ -7,3 +9,31 @@ def get_closest_trading_date(input_date):
         input_date -= timedelta(days=1)
     # Assuming all weekends are non-trading days, for simplicity
     return input_date.strftime('%Y-%m-%d')
+
+
+def get_atm_strike_data(symbol: str, current_price: float, options_data: pandas.DataFrame):
+    """
+    Get the closest strike price to the current price.
+    """
+    # Get the options data for the symbol
+    options_data = options_data[options_data['symbol'] == symbol]
+
+    # Get the unique strike prices for the symbol
+    strike_prices = options_data['strike'].unique()
+
+    # Find the closest strike price
+    closest_strike = min(strike_prices, key=lambda x: abs(x - current_price))
+
+    # Return the row of the closest strike price
+    return options_data[options_data['strike'] == closest_strike]
+
+def extract_symbol_from_contract_id(contract_id: str) -> str:
+    """
+    Extract the symbol from a contract ID. The symbol is all letters until the first number.
+    """
+    symbol = ''
+    for c in contract_id:
+        if c.isdigit():
+            break
+        symbol += c
+    return symbol


### PR DESCRIPTION
The backtester now works with options strategies. We use the DB data when possible, but if the stock makes a big move, we may not have all data we need stored, so we fallback to using the API. I added a dummy strategy that buys an ATM call on Monday and sells it on Friday. Tested it on 6/1/24-12/31/24.